### PR TITLE
Reduce long launch times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,6 @@ RUN git clone https://github.com/BadCafeCode/masquerade-nodes-comfyui.git custom
 RUN git clone https://github.com/melMass/comfy_mtb.git /comfyui/custom_nodes/comfy_mtb && \
     cd /comfyui/custom_nodes/comfy_mtb && \
     pip install -r requirements.txt && \
-    python install.py
 
 RUN git clone https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite.git /comfyui/custom_nodes/ComfyUI-VideoHelperSuite && \
     cd /comfyui/custom_nodes/ComfyUI-VideoHelperSuite && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,9 +125,10 @@ RUN git clone https://github.com/ltdrdata/ComfyUI-Impact-Pack.git /comfyui/custo
 
 RUN git clone https://github.com/BadCafeCode/masquerade-nodes-comfyui.git custom_nodes/masquerade-nodes-comfyui
 
-RUN git clone https://github.com/melMass/comfy_mtb.git /comfyui/custom_nodes/comfy_mtb && \
+# Use Gazai's MTB node since the original one takes too long to compile due to the numba issue.
+RUN git clone https://github.com/gazai-io/comfy_mtb.git /comfyui/custom_nodes/comfy_mtb && \
     cd /comfyui/custom_nodes/comfy_mtb && \
-    pip install -r requirements.txt && \
+    pip install -r requirements.txt
 
 RUN git clone https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite.git /comfyui/custom_nodes/ComfyUI-VideoHelperSuite && \
     cd /comfyui/custom_nodes/ComfyUI-VideoHelperSuite && \


### PR DESCRIPTION
## Motivation

The rembg’s dependency, `pymatting`, uses numba to boost computing. However, the cache for the first-time import of `numba` did not work on RunPod. In this PR, we are using our customized `comfy_mtb` node, which has `numba` removed from its dependencies to improve loading times.

## Issues closed

