### PR TITLE
fix: retry api only when request failed to comfyui api

### DIFF
--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -173,7 +173,7 @@ def queue_workflow(workflow):
         try:
             req = urllib.request.Request(f"http://{COMFY_HOST}/prompt", data=data)
             return json.loads(urllib.request.urlopen(req).read())
-        except Exception as e:
+        except requests.RequestException as e:
             print(f"Error queuing workflow: {str(e)}. Retrying...")
             time.sleep(COMFY_API_AVAILABLE_INTERVAL_MS / 1000)
             retries += 1


### PR DESCRIPTION
## Motivation

Do not retry enqueuing when there are issues with prompts or other errors.

## Issues closed

<!-- List closed issues here -->
